### PR TITLE
Add viral contigs summary table with all phase 1 results

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ The pipeline generates organized results in your specified `output_dir`:
 
 **Detailed Results:**
 - `01_phage_predictions/phageContigs.fasta` - Predicted phage sequences
+- `01_phage_predictions/viral_contigs_summary.tsv` - All viral contigs with pass/fail status and prediction details
 - `02_clustering/vOTU_repSeqs.fasta` - Representative sequences per vOTU (if clustering enabled)
 - `03_checkv_final/quality_summary.tsv` - Quality metrics
 - `03_genomic_info/consensus_taxonomy.tsv` - Integrated taxonomy from multiple tools

--- a/workflow/rules/01_prediction.smk
+++ b/workflow/rules/01_prediction.smk
@@ -600,16 +600,27 @@ rule checkv_assessment:
             -t {threads} > {log} 2>&1
         """
 
+# Helper function to get mmseqs_lca input if it exists (depends on entry point)
+def get_mmseqs_lca_input(wildcards):
+    """Return mmseqs_lca file only if MMseqs filtering was run (not skipped by entry point)."""
+    start_from = config.get("start_from", "assembly")
+    # MMseqs LCA is only available for assembly and reneo_output entry points
+    if start_from in ["assembly", "reneo_output"]:
+        return f"{config['output_dir']}/01_filtered_mmseqs/filtered_lca.tsv"
+    return []
+
 # 8. Integrate phage prediction results
 rule integrate_phage_predictions:
     input:
         phold = f"{config['output_dir']}/01_phold_output/phold_per_cds_predictions.tsv",
         jaeger = f"{config['output_dir']}/01_jaeger_output/passing_Viralcontigs_default_jaeger.tsv",
         genomad = f"{config['output_dir']}/01_genomad_output/passing_Viralcontigs_summary/passing_Viralcontigs_virus_summary.tsv",
-        checkv = f"{config['output_dir']}/01_checkv_output/quality_summary.tsv"
+        checkv = f"{config['output_dir']}/01_checkv_output/quality_summary.tsv",
+        mmseqs_lca = get_mmseqs_lca_input
     output:
         predictions = f"{config['output_dir']}/01_phage_predictions/phagePredictedContigs.tsv",
-        contig_ids = f"{config['output_dir']}/01_phage_predictions/contig_ids.txt"
+        contig_ids = f"{config['output_dir']}/01_phage_predictions/contig_ids.txt",
+        viral_summary = f"{config['output_dir']}/01_phage_predictions/viral_contigs_summary.tsv"
     log:
         f"{config['output_dir']}/logs/integrate_phage_predictions.log"
     conda:

--- a/workflow/scripts/01_phagePrediction.R
+++ b/workflow/scripts/01_phagePrediction.R
@@ -19,19 +19,24 @@ suppressPackageStartupMessages({
 log_info("Starting phage prediction integration")
 
 # Function to process inputs
-process_phage_predictions <- function(phold_file, jager_file, genomad_file, checkv_file, output_table, output_ids) {
+process_phage_predictions <- function(phold_file, jager_file, genomad_file, checkv_file,
+                                       output_table, output_ids, output_viral_summary,
+                                       mmseqs_lca_file = NULL) {
   log_info("Reading input files:")
   log_info(paste("phold file:", phold_file))
   log_info(paste("jager file:", jager_file))
   log_info(paste("genomad file:", genomad_file))
   log_info(paste("checkv file:", checkv_file))
-  
+  if (!is.null(mmseqs_lca_file)) {
+    log_info(paste("mmseqs_lca file:", mmseqs_lca_file))
+  }
+
   # Read and process pholdVirPassed data
   log_info("Processing phold data")
   pholdVirPassed <- vroom(phold_file, delim = "\t", col_names = TRUE)
   log_info(paste("PHOLD raw data rows:", nrow(pholdVirPassed)))
   colnames(pholdVirPassed)[7] <- "category"
-  
+
   # Filter pholdVirPassed
   pholdVirPassed_filt <- pholdVirPassed %>%
     filter(product != "hypothetical protein") %>%
@@ -40,9 +45,9 @@ process_phage_predictions <- function(phold_file, jager_file, genomad_file, chec
     filter(category != "transcription regulation") %>%
     filter(category != "unknown function") %>%
     filter(category != "DNA, RNA and nucleotide metabolism")
-  
+
   log_info(paste("PHOLD filtered data rows:", nrow(pholdVirPassed_filt)))
-  
+
   # Group and count phage-related proteins
   # Handle empty PHOLD results gracefully
   if (nrow(pholdVirPassed_filt) == 0) {
@@ -60,11 +65,11 @@ process_phage_predictions <- function(phold_file, jager_file, genomad_file, chec
       group_by(contig_id, category) %>%
       dplyr::count(contig_id, category) %>%
       dcast(contig_id ~ category, value.var = "n")
-    
+
     phrogsPerContig[is.na(phrogsPerContig)] <- 0
     colnames(phrogsPerContig) <- c("contig_id", "Connector", "Head_Packaging", "Integration_Excision", "Lysis", "Tail")
   }
-  
+
   # Add functional diversity
   if (nrow(phrogsPerContig) == 0) {
     phrogsPerContig$Functionaldiversity <- numeric(0)
@@ -76,27 +81,131 @@ process_phage_predictions <- function(phold_file, jager_file, genomad_file, chec
       ) %>%
       ungroup()
   }
-  
-  # Read and process jager data
+
+  # Read and process jager data (keep ALL predictions, not just phages)
   log_info("Processing jaeger data")
   jager <- vroom(jager_file, delim = "\t", col_names = TRUE)
+
+  # Create filtered version for phage calling (score >= 0.6 and prediction == "Phage")
   phages_jager <- jager %>%
     filter(prediction == "Phage") %>%
     filter(realiability_score >= 0.6)
-  
+
   # Read and process genomad data
   log_info("Processing genomad data")
   genomad <- vroom(genomad_file, delim = "\t", col_names = TRUE)
-  colnames(genomad) <- c("contig_id", "genomad_Length", "genomad_topology", 
-                         "genomad_coordinates", "genomad_n_genes", "genomad_genetic_code", 
+  colnames(genomad) <- c("contig_id", "genomad_Length", "genomad_topology",
+                         "genomad_coordinates", "genomad_n_genes", "genomad_genetic_code",
                          "genomad_virus_score", "genomad_fdr", "genomad_n_hallmarks","genomad_marker_enrichment", "genomad_taxonomy")
-  
+
   # Read and process checkv data
   log_info("Processing checkv data")
   checkv <- vroom(checkv_file, delim = "\t", col_names = TRUE)
-  
-  # Create phagePredictedContigs table
-  log_info("Integrating results to identify phage contigs")
+
+  # Read mmseqs LCA data if provided
+  mmseqs_lca <- NULL
+  if (!is.null(mmseqs_lca_file) && file.exists(mmseqs_lca_file)) {
+    log_info("Processing mmseqs LCA data")
+    # The filtered_lca.tsv has no header - 10 columns
+    mmseqs_lca <- vroom(mmseqs_lca_file, delim = "\t", col_names = FALSE)
+    colnames(mmseqs_lca) <- c("contig_id", "taxid", "rank", "taxname",
+                              "col5", "col6", "col7", "col8", "col9", "col10")
+    mmseqs_lca <- mmseqs_lca %>% select(contig_id, taxid, taxname)
+    colnames(mmseqs_lca) <- c("contig_id", "mmseqs_taxid", "mmseqs_lca")
+    log_info(paste("MMseqs LCA data rows:", nrow(mmseqs_lca)))
+  }
+
+  # ============================================================================
+  # Create COMPREHENSIVE viral contigs summary (ALL viral contigs)
+  # ============================================================================
+  log_info("Creating comprehensive viral contigs summary")
+
+  # Start with CheckV as the base (has all viral contigs)
+  viral_summary <- checkv %>%
+    select(contig_id, contig_length, checkv_quality, completeness, contamination, provirus)
+
+  # Add mmseqs LCA info if available
+  if (!is.null(mmseqs_lca)) {
+    viral_summary <- viral_summary %>%
+      left_join(mmseqs_lca, by = "contig_id")
+  }
+
+  # Add PHOLD functional diversity
+  viral_summary <- viral_summary %>%
+    left_join(phrogsPerContig %>% select(contig_id, Functionaldiversity), by = "contig_id") %>%
+    mutate(Functionaldiversity = ifelse(is.na(Functionaldiversity), 0, Functionaldiversity))
+
+  # Add ALL Jaeger results (not just filtered phages)
+  jaeger_summary <- jager %>%
+    select(contig_id, prediction, realiability_score) %>%
+    rename(jaeger_prediction = prediction, jaeger_score = realiability_score)
+
+  viral_summary <- viral_summary %>%
+    left_join(jaeger_summary, by = "contig_id")
+
+  # Add genomad results
+  genomad_summary <- genomad %>%
+    select(contig_id, genomad_topology, genomad_virus_score, genomad_taxonomy)
+
+  viral_summary <- viral_summary %>%
+    left_join(genomad_summary, by = "contig_id")
+
+  # Add is_phage flag and prediction_rule
+  viral_summary <- viral_summary %>%
+    mutate(
+      # Check if Jaeger called it a phage with sufficient score
+      jaeger_phage = !is.na(jaeger_score) & jaeger_prediction == "Phage" & jaeger_score >= 0.6,
+      # Determine is_phage status
+      is_phage = case_when(
+        Functionaldiversity >= 3 ~ TRUE,
+        Functionaldiversity < 3 & genomad_topology %in% c("DTR", "ITR", "Provirus") ~ TRUE,
+        Functionaldiversity >= 1 & Functionaldiversity < 3 & (jaeger_phage | !is.na(genomad_virus_score)) ~ TRUE,
+        Functionaldiversity < 1 & jaeger_phage & !is.na(genomad_virus_score) ~ TRUE,
+        TRUE ~ FALSE
+      ),
+      # Create prediction rule explaining why it passed or failed
+      prediction_rule = case_when(
+        Functionaldiversity >= 3 ~ "high_functional_diversity",
+        Functionaldiversity < 3 & genomad_topology %in% c("DTR", "ITR", "Provirus") ~ "special_topology",
+        Functionaldiversity >= 1 & Functionaldiversity < 3 & (jaeger_phage | !is.na(genomad_virus_score)) ~ "moderate_diversity_with_tool_support",
+        Functionaldiversity < 1 & jaeger_phage & !is.na(genomad_virus_score) ~ "dual_tool_agreement",
+        # Exclusion reasons
+        Functionaldiversity < 1 & !jaeger_phage & is.na(genomad_virus_score) ~ "low_diversity_no_tool_support",
+        Functionaldiversity >= 1 & Functionaldiversity < 3 & !jaeger_phage & is.na(genomad_virus_score) ~ "moderate_diversity_no_tool_support",
+        Functionaldiversity < 1 & (jaeger_phage | !is.na(genomad_virus_score)) ~ "low_diversity_single_tool_only",
+        TRUE ~ "no_criteria_met"
+      )
+    ) %>%
+    select(-jaeger_phage)  # Remove helper column
+
+  # Reorder columns for clarity
+  col_order <- c("contig_id", "contig_length", "is_phage", "prediction_rule",
+                 "checkv_quality", "completeness", "contamination", "provirus",
+                 "Functionaldiversity", "jaeger_prediction", "jaeger_score",
+                 "genomad_topology", "genomad_virus_score", "genomad_taxonomy")
+
+  # Add mmseqs columns if present
+  if (!is.null(mmseqs_lca)) {
+    col_order <- c(col_order[1:2], "mmseqs_taxid", "mmseqs_lca", col_order[3:length(col_order)])
+  }
+
+  # Select only columns that exist
+  col_order <- col_order[col_order %in% colnames(viral_summary)]
+  viral_summary <- viral_summary %>% select(all_of(col_order))
+
+  log_info(paste("Total viral contigs:", nrow(viral_summary)))
+  log_info(paste("Phage contigs:", sum(viral_summary$is_phage)))
+  log_info(paste("Non-phage viral contigs:", sum(!viral_summary$is_phage)))
+
+  # Write viral contigs summary
+  log_info(paste("Writing viral contigs summary to:", output_viral_summary))
+  vroom::vroom_write(viral_summary, output_viral_summary, delim = "\t")
+
+  # ============================================================================
+  # Create filtered phage predictions table (existing behavior)
+  # ============================================================================
+  log_info("Creating filtered phage predictions table")
+
   phagePredictedContigs <- checkv[, c("contig_id", "contig_length", "completeness")] %>%
     left_join(phrogsPerContig[, c("contig_id", "Functionaldiversity")], by = "contig_id") %>%
     left_join(phages_jager[, c("contig_id", "realiability_score")], by = "contig_id") %>%
@@ -113,55 +222,67 @@ process_phage_predictions <- function(phold_file, jager_file, genomad_file, chec
     ) %>%
     filter(is_phage == TRUE) %>%
     select(-is_phage)
-  
+
   # Extract contig_id vector
   contig_ids <- phagePredictedContigs$contig_id
   log_info(paste("Found", length(contig_ids), "phage contigs"))
-  
+
   # Save outputs
   log_info(paste("Writing outputs to:", output_table, "and", output_ids))
   vroom::vroom_write(phagePredictedContigs, output_table, delim = "\t")
   writeLines(contig_ids, output_ids)
-  
+
   log_info("Phage prediction integration completed")
 }
 
 # Handle snakemake or command line execution
 if (exists("snakemake")) {
   log_appender(appender_file(snakemake@log[[1]]))
-  
+
+  # Get optional mmseqs_lca input (may not be present in all entry points)
+  mmseqs_lca_file <- NULL
+  if ("mmseqs_lca" %in% names(snakemake@input)) {
+    mmseqs_lca_file <- snakemake@input$mmseqs_lca
+  }
+
   process_phage_predictions(
     snakemake@input$phold,
     snakemake@input$jaeger,
     snakemake@input$genomad,
     snakemake@input$checkv,
     snakemake@output$predictions,
-    snakemake@output$contig_ids
+    snakemake@output$contig_ids,
+    snakemake@output$viral_summary,
+    mmseqs_lca_file
   )
 } else {
   # Parse command line arguments
   args <- commandArgs(trailingOnly = TRUE)
   if (length(args) < 5) {
-    stop("Usage: Rscript script.R <phold_file> <jager_file> <genomad_file> <checkv_file> <output_dir>")
+    stop("Usage: Rscript script.R <phold_file> <jager_file> <genomad_file> <checkv_file> <output_dir> [mmseqs_lca_file]")
   }
-  
+
   phold_file <- args[1]
   jager_file <- args[2]
   genomad_file <- args[3]
   checkv_file <- args[4]
   output_dir <- args[5]
-  
+  mmseqs_lca_file <- if (length(args) >= 6) args[6] else NULL
+
   # Create output paths
   output_table_path <- file.path(output_dir, "phagePredictedContigs.tsv")
   output_vector_path <- file.path(output_dir, "contig_ids.txt")
-  
+  output_viral_summary_path <- file.path(output_dir, "viral_contigs_summary.tsv")
+
   # Process inputs
   process_phage_predictions(
     phold_file,
     jager_file,
-    genomad_file, 
+    genomad_file,
     checkv_file,
     output_table_path,
-    output_vector_path
+    output_vector_path,
+    output_viral_summary_path,
+    mmseqs_lca_file
   )
 }


### PR DESCRIPTION
## Summary
Adds a new output file `viral_contigs_summary.tsv` that includes ALL viral contigs from phase 1, not just those that pass the phage prediction criteria. This makes it easier to investigate why specific contigs weren't called as phages.

## Changes
- Modified `workflow/scripts/01_phagePrediction.R` to output comprehensive summary
- Updated `workflow/rules/01_prediction.smk` to include new output
- Added to README documentation

## New Output
**Location:** `{output_dir}/01_phage_predictions/viral_contigs_summary.tsv`

| Column | Description |
|--------|-------------|
| `contig_id`, `contig_length` | Basic info |
| `is_phage` | TRUE/FALSE |
| `prediction_rule` | Why it passed/failed (e.g., `high_functional_diversity`, `low_diversity_no_tool_support`) |
| `checkv_quality`, `completeness`, `contamination`, `provirus` | CheckV metrics |
| `Functionaldiversity` | PHOLD functional categories count |
| `jaeger_prediction`, `jaeger_score` | Jaeger results |
| `genomad_topology`, `genomad_virus_score`, `genomad_taxonomy` | geNomad results |
| `mmseqs_taxid`, `mmseqs_lca` | Initial viral classification (when available) |

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)